### PR TITLE
remove page reload on blur

### DIFF
--- a/client/js/app.js
+++ b/client/js/app.js
@@ -1,9 +1,3 @@
-window.focus();
-
-window.addEventListener('blur', () => {
-  window.location.reload();
-});
-
 window.addEventListener('load', (event) => {
   slider();
   modal();


### PR DESCRIPTION
### Why update
Initially, the page reloads when it lost focus... this is useful when in the development and when not using live server....

### changes made
The page will no longer reload when it lost focus. reload manually or install a live server script.....

### file changed
- `js/app.js` : removed the code that makes the page reloads